### PR TITLE
fixed bug that occurs when using a 2 in 1 model

### DIFF
--- a/jarbas_wake_word_plugin_snowboy/__init__.py
+++ b/jarbas_wake_word_plugin_snowboy/__init__.py
@@ -29,9 +29,13 @@ class SnowboyHotWord(HotWordEngine):
         for model in models:
             path = model.get("model_path", key_phrase)
             sensitivity = model.get("sensitivity", 0.5)
-            paths.append(find_model(path))
-            sensitivities.append(sensitivity)
+            if type(sensitivity) == list:
+                sensitivities.extend(sensitivity)
+            else:
+                sensitivities.append(sensitivity)
 
+            paths.append(find_model(path))
+            
         # load snowboy
         self.snowboy = get_detector(paths, sensitivity=sensitivities)
 


### PR DESCRIPTION
some models have more than one model in them like jarvis.umdl in which case this gives the error of unmatched sensitivities. This fixes the issue.